### PR TITLE
feat: update required Terraform version and add VPC endpoint ARN output

### DIFF
--- a/aws/s3-bucket-object/versions.tf
+++ b/aws/s3-bucket-object/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.24"
+      version = ">= 5.26"
     }
   }
 }

--- a/aws/vpc-endpoint/outputs.tf
+++ b/aws/vpc-endpoint/outputs.tf
@@ -3,6 +3,11 @@ output "endpoints" {
   value       = aws_vpc_endpoint.this
 }
 
+output "endpoint_arn" {
+  description = "VPC endpoint arns"
+  value       = aws_vpc_endpoint.this[*].arn
+}
+
 output "security_group_arn" {
   description = "Amazon Resource Name (ARN) of the security group"
   value       = aws_security_group.this.arn


### PR DESCRIPTION
- Increased the required Terraform version for the module in the versions.tf file.
- Added a new output for the VPC endpoint ARN, which can be utilized by various consumers for integrated resources.

---

This PR showcases updates to two separate modules, each reflected in their respective commits:

`aws/vpc-endpoint`: The required Terraform version has been increased, resulting in a minor version bump due to the addition of new features.

`aws/s3-bucket-object`: A new output for the VPC endpoint ARN has been added, leading to a patch version bump as it enhances existing functionality without breaking changes.