### PR TITLE
chore: update aws/vpc-endpoint module version and clean up assets

### DIFF
--- a/.github/workflows/terraform-module-releaser.yml
+++ b/.github/workflows/terraform-module-releaser.yml
@@ -17,4 +17,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Terraform Module Releaser
-        uses: techpivot/terraform-module-releaser@v1.1.1
+        uses: techpivot/terraform-module-releaser@v1.3.0

--- a/aws/s3-bucket-object/versions.tf
+++ b/aws/s3-bucket-object/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.26"
+      version = ">= 5.27"
     }
   }
 }

--- a/aws/vpc-endpoint/README.md
+++ b/aws/vpc-endpoint/README.md
@@ -3,3 +3,7 @@
 Sample Terraform module which creates VPC endpoint resources on AWS.
 
 This is a demo Terraform module.
+
+## References
+
+- Testing add documentation here that should **not** trigger a new relase.


### PR DESCRIPTION
### Description

This pull request contains two commits:

1. **docs:** Update documentation for the `aws/vpc-endpoint` module.
   - This change does not trigger a Terraform module update.

2. **chore:** Bump version of the `aws/vpc-endpoint` module.
   - The version has been updated in accordance with Terraform changes.

### Additional Changes

- Updated to use the latest `terraform-module-release` (1.3.0).
- Assets built for the module do not include the `README.md`.

## Validation

✅ We confirm below via the terraform-module-releaser that the `aws/vpc-endpoint` module will not be triggered since it contained only documentation change.