### PR TITLE
chore: update terraform-module-releaser to v1.4.0 and enable SSH source format

### DIFF
--- a/.github/workflows/terraform-module-releaser.yml
+++ b/.github/workflows/terraform-module-releaser.yml
@@ -17,4 +17,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Terraform Module Releaser
-        uses: techpivot/terraform-module-releaser@v1.3.0
+        uses: techpivot/terraform-module-releaser@v1.4.0
+        with:
+          use-ssh-source-format: true


### PR DESCRIPTION
This pull request includes an update to the Terraform Module Releaser action in the GitHub workflow configuration file.

* [`.github/workflows/terraform-module-releaser.yml`](diffhunk://#diff-837dbb1aa2ee9f821342f55fa9db36f2b21e433b1c68aa21576e4baf7e232a7fL20-R22): Updated the Terraform Module Releaser action to version `v1.4.0` and added the `use-ssh-source-format` parameter set to `true`.