### PR TITLE
chore: update actions/checkout to v6 and improve documentation in vpc-endpoint module

### DIFF
--- a/.github/workflows/terraform-module-releaser.yml
+++ b/.github/workflows/terraform-module-releaser.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Terraform Module Releaser
         uses: techpivot/terraform-module-releaser@v1

--- a/aws/vpc-endpoint/main.tf
+++ b/aws/vpc-endpoint/main.tf
@@ -1,5 +1,5 @@
 locals {
-  # Documentation
+  # Documentation A
   endpoints = { for k, v in var.endpoints : k => v }
 
   security_group_ids = concat(var.security_group_ids, [aws_security_group.this.id])


### PR DESCRIPTION
Testing checkout v6. This should fail when creating tags ...